### PR TITLE
change default image registy to localhost

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-IMAGE_REGISTRY?=ger-is-registry.caas.intel.com/cno/k8s-p4/
+IMAGE_REGISTRY?=localhost:5000/
 IMAGE_VERSION?=latest
 export INFRAAGENT_IMAGE?=$(IMAGE_REGISTRY)infraagent:$(IMAGE_VERSION)
 export INFRAMANAGER_IMAGE?=$(IMAGE_REGISTRY)inframanager:$(IMAGE_VERSION)


### PR DESCRIPTION
Changes default IMAGE_REGISTRY value to localhost:5000/. User is expected to provide their own image registy URL when building contianer images.

Signed-off-by: Abdul Halim <abdul.halim@intel.com>