### PR TITLE
Added default routing via 169.254.1.1

### DIFF
--- a/pkg/netconf/tap.go
+++ b/pkg/netconf/tap.go
@@ -75,16 +75,20 @@ func configureTapNamespace(in *pb.AddRequest, linkObj netlink.Link) error {
 			return err
 		}
 
-		if err = setLinkAddressFunc(linkObj, in.ContainerIps); err != nil {
-			return fmt.Errorf("Cannot set link address: %w", err)
-		}
-
 		if err = linkSetUp(linkObj); err != nil {
 			return fmt.Errorf("Cannot set link up: %w", err)
 		}
 
-		if err := setupPodRoute(linkObj, in.ContainerRoutes, nonTargetIP); err != nil {
+		if err := setupGwRoute(linkObj, types.DefaultRoute); err != nil {
 			return fmt.Errorf("Cannot setup routes: %w", err)
+		}
+
+		if err := setupPodRoute(linkObj, in.ContainerRoutes, types.DefaultRoute); err != nil {
+			return fmt.Errorf("Cannot setup routes: %w", err)
+		}
+
+		if err = setLinkAddressFunc(linkObj, in.ContainerIps); err != nil {
+			return fmt.Errorf("Cannot set link address: %w", err)
 		}
 
 		return nil

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -47,6 +47,7 @@ const (
 	InfraAgentLogDir            = "/var/log/infraagent"
 	InfraAgentCLIName           = "infraagent"
 	HostInterfaceRefId          = "hostInterface"
+	DefaultRoute                = "169.254.1.1/32"
 )
 
 var (


### PR DESCRIPTION
This PR changes InfraAgent's default routing configuration for pods to:

default via 169.254.1.1 dev eth0
169.254.1.1 dev eth0 scope link

**NOTE**: Please be aware that merging this PR will require changes in pod networking handling in InfraManager as well.

Signed-off-by: ipatrykx <patrykx.strusiewicz-surmacki@intel.com>