### PR TITLE
change infra-manager imagePull policy to 'Always'

### DIFF
--- a/deploy/inframanager-daemonset.yaml
+++ b/deploy/inframanager-daemonset.yaml
@@ -34,7 +34,7 @@ spec:
       containers:
       - name: manager
         image: inframanager:latest
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         volumeMounts:
         - name: log
           mountPath: /var/log


### PR DESCRIPTION
For development and testing changing infra-manager daemonset imagePull policy to Always so that we ensure latest image gets deployed.

Signed-off-by: Abdul Halim <abdul.halim@intel.com>