### PR TITLE
Remove in cluster client config option for Infra Agent

### DIFF
--- a/deploy/infraagent-daemonset.yaml
+++ b/deploy/infraagent-daemonset.yaml
@@ -32,7 +32,7 @@ spec:
       hostNetwork: true
       serviceAccountName: infraagent-sa
       initContainers:
-      - name: init
+      - name: install-felix-proxy
         image: infraagent:latest
         imagePullPolicy: Always
         volumeMounts:
@@ -97,6 +97,8 @@ spec:
           mountPath: /var/lib/cni/infraagent
         - name: cni-cache
           mountPath: /var/lib/cni/networks
+        - name: kubeconfig
+          mountPath: /root/.kube
         command:
         - /infraagent
       volumes:
@@ -122,6 +124,9 @@ spec:
       - name: config-volume
         configMap:
           name: infraagent-config
+      - name: kubeconfig
+        configMap:
+          name: infra-kubeconfig
       - name: cache
         hostPath:
           path: /var/lib/cni/infraagent

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -168,10 +168,6 @@ func GetNodeNetInterface(k8sclient kubernetes.Interface, nodeName string, ifGett
 }
 
 func GetK8sConfig() (*rest.Config, error) {
-	clusterConfig, err := restInClusterConfig()
-	if err == nil {
-		return clusterConfig, nil
-	}
 	var kubeconfig string
 	if home := homedir.HomeDir(); home != "" {
 		kubeconfig = filepath.Join(home, ".kube", "config")

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -206,16 +206,7 @@ var _ = Describe("utils", func() {
 	})
 
 	var _ = Context("GetK8sConfig() should", func() {
-		var _ = It("return no error when inCluster config is available", func() {
-			restInClusterConfigBackup := restInClusterConfig
-			restInClusterConfig = func() (*rest.Config, error) { return &rest.Config{}, nil }
-			_, err := GetK8sConfig()
-			Expect(err).ToNot(HaveOccurred())
-			restInClusterConfig = restInClusterConfigBackup
-		})
-		var _ = It("return no error when can build config from file", func() {
-			restInClusterConfigBackup := restInClusterConfig
-			restInClusterConfig = func() (*rest.Config, error) { return nil, errors.New("InClusterConfig unavailable") }
+		var _ = It("return no error when it can build config from file", func() {
 			t := testing.T{}
 			t.Setenv("HOME", tempDir)
 			_, tearDown, err := prepareKubeConfig(tempDir, exampleConfig)
@@ -223,12 +214,9 @@ var _ = Describe("utils", func() {
 			defer tearDown()
 			_, err = GetK8sConfig()
 			Expect(err).ToNot(HaveOccurred())
-			restInClusterConfig = restInClusterConfigBackup
 		})
 
 		var _ = It("return error if config file is invalid", func() {
-			restInClusterConfigBackup := restInClusterConfig
-			restInClusterConfig = func() (*rest.Config, error) { return nil, errors.New("InClusterConfig unavailable") }
 			t := testing.T{}
 			t.Setenv("HOME", tempDir)
 			_, tearDown, err := prepareKubeConfig(tempDir, "BrokenConfig")
@@ -236,7 +224,6 @@ var _ = Describe("utils", func() {
 			defer tearDown()
 			_, err = GetK8sConfig()
 			Expect(err).To(HaveOccurred())
-			restInClusterConfig = restInClusterConfigBackup
 		})
 	})
 


### PR DESCRIPTION
Removing in-cluster client config option as k8s service is not expected to be ready when Infra Agent is deployed. Instead we are going to use out-of-cluster client using user provided kubeconfig during deployment.
This kubeconfig will be read from user home directory or user can override it using KUBECONFIG env variable during deployment.