### PR TITLE
use static addresses for host & backened interfaces

### DIFF
--- a/deploy/infraagent-daemonset.yaml
+++ b/deploy/infraagent-daemonset.yaml
@@ -40,20 +40,6 @@ spec:
           mountPath: /var/lib/calico
         command: ["/bin/sh", "-c"]
         args: ["mkdir -p /var/lib/calico/felix-plugins && cp felix-api-proxy /var/lib/calico/felix-plugins/felix-api-proxy"]
-      - name: wait-for-calico
-        image: infraagent:latest
-        imagePullPolicy: Always
-        command:
-        - /infraagent
-        - checkCalicoConfig
-        env:
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        volumeMounts:
-        - name: cni-net
-          mountPath: /etc/cni/net.d
       - name: wait-for-manager
         image: infraagent:latest
         imagePullPolicy: Always

--- a/inframanager/api_handler/api_handler.go
+++ b/inframanager/api_handler/api_handler.go
@@ -167,7 +167,7 @@ func CreateServer(log *log.Entry) *ApiServer {
 
 func InsertDefaultRule() {
 	server := NewApiServer()
-	p4.ArptToPortTable(context.Background(), server.p4RtC, types.DefaultRoute,
+	p4.ArptToPortTable(context.Background(), server.p4RtC, types.HostInterfaceAddr,
 		types.ArpProxyDefaultPort, true)
 }
 

--- a/pkg/netconf/tap.go
+++ b/pkg/netconf/tap.go
@@ -79,11 +79,11 @@ func configureTapNamespace(in *pb.AddRequest, linkObj netlink.Link) error {
 			return fmt.Errorf("Cannot set link up: %w", err)
 		}
 
-		if err := setupGwRoute(linkObj, types.DefaultRoute); err != nil {
+		if err := setupGwRoute(linkObj, types.PodDefaultGWAddr); err != nil {
 			return fmt.Errorf("Cannot setup routes: %w", err)
 		}
 
-		if err := setupPodRoute(linkObj, in.ContainerRoutes, types.DefaultRoute); err != nil {
+		if err := setupPodRoute(linkObj, in.ContainerRoutes, types.PodDefaultGWAddr); err != nil {
 			return fmt.Errorf("Cannot setup routes: %w", err)
 		}
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -47,7 +47,9 @@ const (
 	InfraAgentLogDir            = "/var/log/infraagent"
 	InfraAgentCLIName           = "infraagent"
 	HostInterfaceRefId          = "hostInterface"
-	DefaultRoute                = "169.254.1.1/32"
+	BackendInterfaceRefId       = "backendInterface"
+	HostInterfaceAddr           = "200.1.1.2/32"
+	PodDefaultGWAddr            = "200.1.1.1/32"
 	ArpProxyDefaultPort         = 0
 )
 


### PR DESCRIPTION
To remove calico dependencies we are going to use static addresses for host interface.
We are aslo adding one other interace called 'backendInterface' which will be used to hold the Pod GW address as a default route from Pod.

Both of these addresses are taken from variables in pkg/types/types.go.

Signed-off-by: Abdul Halim <abdul.halim@intel.com>