### PR TITLE
Change the store path to /var/lib/cni/inframanager

### DIFF
--- a/deploy/inframanager-daemonset.yaml
+++ b/deploy/inframanager-daemonset.yaml
@@ -39,7 +39,7 @@ spec:
         - name: log
           mountPath: /var/log
         - name: db
-          mountPath: /opt/inframanager
+          mountPath: /var/lib/cni/inframanager
         command:
         - /inframanager
       volumes:
@@ -49,7 +49,7 @@ spec:
           type: DirectoryOrCreate
       - name: db
         hostPath:
-          path: /opt/inframanager
+          path: /var/lib/cni/inframanager
           type: DirectoryOrCreate
   updateStrategy:
     rollingUpdate:

--- a/pkg/inframanager/store/storedefinition.go
+++ b/pkg/inframanager/store/storedefinition.go
@@ -18,6 +18,10 @@ import (
 	"sync"
 )
 
+const (
+	storePath = "/var/lib/cni/inframanager/"
+)
+
 type store interface {
 	WriteToStore() bool
 	DeleteFromStore() bool

--- a/pkg/inframanager/store/storeendpoint.go
+++ b/pkg/inframanager/store/storeendpoint.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	storeFile = "/opt/inframanager/cni_db.json"
+	storeFile = storePath + "cni_db.json"
 )
 
 func isEndPointStoreEmpty() bool {

--- a/pkg/inframanager/store/storeservice.go
+++ b/pkg/inframanager/store/storeservice.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	servicesFile = "/opt/inframanager/services_db.json"
+	servicesFile = storePath + "services_db.json"
 )
 
 func isServiceStoreEmpty() bool {


### PR DESCRIPTION
Change the path where the store maintains the information about the programmed dpdk rules

Change the path from /opt/inframanager to /var/lib/cni/inframanager

Signed-off-by: Venkatesh Petla <neelakanta.venkatesh.petla@intel.com>