### PR TITLE
Add rule for host IP

### DIFF
--- a/deploy/inframanager-daemonset.yaml
+++ b/deploy/inframanager-daemonset.yaml
@@ -42,6 +42,11 @@ spec:
           mountPath: /opt/inframanager
         command:
         - /inframanager
+        env:
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
       volumes:
       - name: log
         hostPath:

--- a/inframanager/api_handler/api_handler.go
+++ b/inframanager/api_handler/api_handler.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/ipdk-io/k8s-infra-offload/pkg/types"
-	"github.com/ipdk-io/k8s-infra-offload/pkg/utils"
 	"github.com/ipdk-io/k8s-infra-offload/proto"
 	"gopkg.in/tomb.v2"
 
@@ -250,7 +249,7 @@ func InsertDefaultRule() {
 		return
 	}
 
-	utils.UNUSED(netIp)
+	_ = netIp
 
 	ip := IP.String()
 	if len(ip) == 0 {

--- a/pkg/inframanager/config/format.go
+++ b/pkg/inframanager/config/format.go
@@ -20,6 +20,7 @@ type Configuration struct {
 	Client        ClientConf
 	GNMIServer    ServerConf
 	HostName      string
+	NodeIP        string
 	LogLevel      string
 	P4ProgConf    string
 	P4InfoPath    string

--- a/pkg/inframanager/inframanager.go
+++ b/pkg/inframanager/inframanager.go
@@ -100,9 +100,11 @@ func (m *Manager) stopServer() {
 
 func Run(stopCh <-chan struct{}, waitCh chan<- struct{}) {
 
-	manager.createAndStartServer()
-
+	// Insert the default rule for the arp-proxy
 	api.InsertDefaultRule()
+
+	// Start the api server
+	manager.createAndStartServer()
 
 	<-stopCh
 

--- a/pkg/inframanager/p4/cni.go
+++ b/pkg/inframanager/p4/cni.go
@@ -44,9 +44,12 @@ func ArptToPortTable(ctx context.Context, p4RtC *client.Client, arpTpa string, p
 			nil,
 		)
 		if err = p4RtC.InsertTableEntry(ctx, entryAdd); err != nil {
-			log.Errorf("Cannot insert entry into arpt_to_port_table table: %v", err)
+			log.Errorf("Cannot insert entry into arpt_to_port_table table, ip: %s, port: %d, err: %v",
+				arpTpa, port, err)
 			return err
 		}
+		log.Debugf("Successfully inserted entry into arpt_to_port_table, ip: %s, port: %d",
+			arpTpa, port)
 	} else {
 		entryDelete := p4RtC.NewTableEntry(
 			"k8s_dp_control.arpt_to_port_table",
@@ -59,9 +62,12 @@ func ArptToPortTable(ctx context.Context, p4RtC *client.Client, arpTpa string, p
 			nil,
 		)
 		if err = p4RtC.DeleteTableEntry(ctx, entryDelete); err != nil {
-			log.Errorf("Cannot delete entry from arpt_to_port_table table: %v", err)
+			log.Errorf("Cannot delete entry from arpt_to_port_table table, ip: %s, port: %d, err: %v",
+				arpTpa, port, err)
 			return err
 		}
+		log.Debugf("Successfully deleted entry from arpt_to_port_table, ip: %s, port: %d",
+			arpTpa, port)
 	}
 
 	return nil

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2022 Intel Corporation.  All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"fmt"
+	"os"
+)
+
+func GetNodeIPFromEnv() (ipAddr string, err error) {
+	ipAddr = os.Getenv("NODE_IP")
+	if len(ipAddr) == 0 {
+		err = fmt.Errorf("NODE_IP env variable is not set")
+	}
+	return ipAddr, err
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -540,13 +540,3 @@ func CheckGrpcServerStatus(target string, log *log.Entry, grpcDial grpcDialType)
 	}
 	return resp.Status == healthpb.HealthCheckResponse_SERVING, nil
 }
-
-func GetNodeIPFromEnv() (ipAddr string, err error) {
-	ipAddr = os.Getenv("NODE_IP")
-	if len(ipAddr) == 0 {
-		err = fmt.Errorf("NODE_IP env variable is not set")
-	}
-	return ipAddr, err
-}
-
-func UNUSED(x ...interface{}) {}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -540,3 +540,13 @@ func CheckGrpcServerStatus(target string, log *log.Entry, grpcDial grpcDialType)
 	}
 	return resp.Status == healthpb.HealthCheckResponse_SERVING, nil
 }
+
+func GetNodeIPFromEnv() (ipAddr string, err error) {
+	ipAddr = os.Getenv("NODE_IP")
+	if len(ipAddr) == 0 {
+		err = fmt.Errorf("NODE_IP env variable is not set")
+	}
+	return ipAddr, err
+}
+
+func UNUSED(x ...interface{}) {}


### PR DESCRIPTION
Add a rule to the dpdk pipeline for forwarding the packets to/from host IP. Forward them via the default host interface and its port id.

How to get the host IP from the inframanager pod?
Kubernetes populates the pod object in the apiserver with spec:
nodeName: node1
status:
podIP: 172.168.0.2
hostIP: 192.168.0.1

Here hostIP is the nodeIP on which the pod is running on.

Inside the inframanager pod, read the node IP from the pod object and use it for programming the forwarding rules.

This PR also includes fix for failure to program default route for arp-proxy.

Signed-off-by: Venkatesh Petla <neelakanta.venkatesh.petla@intel.com>