### PR TITLE
use static address for host interface

### DIFF
--- a/deploy/infraagent-daemonset.yaml
+++ b/deploy/infraagent-daemonset.yaml
@@ -40,20 +40,6 @@ spec:
           mountPath: /var/lib/calico
         command: ["/bin/sh", "-c"]
         args: ["mkdir -p /var/lib/calico/felix-plugins && cp felix-api-proxy /var/lib/calico/felix-plugins/felix-api-proxy"]
-      - name: wait-for-calico
-        image: infraagent:latest
-        imagePullPolicy: Always
-        command:
-        - /infraagent
-        - checkCalicoConfig
-        env:
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        volumeMounts:
-        - name: cni-net
-          mountPath: /etc/cni/net.d
       - name: wait-for-manager
         image: infraagent:latest
         imagePullPolicy: Always

--- a/pkg/netconf/netutils.go
+++ b/pkg/netconf/netutils.go
@@ -204,6 +204,9 @@ func configureRouting(link netlink.Link, log *logrus.Entry) error {
 	if err := configureRoutingForCIDR(link, types.NodePodsCIDR, log); err != nil {
 		return fmt.Errorf("Failed to setup routing to Pods CIDR: %w", err)
 	}
+	if err := configureRoutingForCIDR(link, types.ClusterServicesSubnet, log); err != nil {
+		return fmt.Errorf("Failed to setup routing to Service CIDR: %w", err)
+	}
 	return nil
 }
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -48,6 +48,7 @@ const (
 	InfraAgentCLIName           = "infraagent"
 	HostInterfaceRefId          = "hostInterface"
 	DefaultRoute                = "169.254.1.1/32"
+	HostInterfaceAddr           = "200.1.1.2/32"
 	ArpProxyDefaultPort         = 0
 )
 


### PR DESCRIPTION
-   Use a static address for host interface to avoid IP allocation
    dependency on Calico config file.
-  remove wait-for-calico init container
-  add ServiceCIDR route to host interface
- update pkg/netconf unit tests