### PR TITLE
set host TAP interface mtu 1280

### DIFF
--- a/pkg/netconf/netconf_test.go
+++ b/pkg/netconf/netconf_test.go
@@ -235,6 +235,7 @@ var _ = Describe("netconf", func() {
 			addrDel = fakeAddrAddDelErr
 			addrAdd = fakeAddrAddDel
 			linkSetUp = fakeLinkSet
+			linkSetMTU = fakeLinkSetMTU
 			configureRoutingFunc = fakeConfigureRouting
 			err := configureHostInterface("dummyIf", &net.IPNet{}, []*types.InterfaceInfo{}, logrus.NewEntry(logrus.New()))
 			Expect(err).ToNot(HaveOccurred())
@@ -1529,6 +1530,9 @@ func fakeLinkByNameErr(name string) (netlink.Link, error) {
 }
 
 func fakeLinkSet(link netlink.Link) error {
+	return nil
+}
+func fakeLinkSetMTU(link netlink.Link, mtu int) error {
 	return nil
 }
 

--- a/pkg/netconf/tappodinterface.go
+++ b/pkg/netconf/tappodinterface.go
@@ -150,6 +150,13 @@ func configureHostInterface(ifName string, ipnet *net.IPNet, interfaces []*types
 		log.WithError(err).Error("Failed to set ip address for interface")
 		return err
 	}
+
+	if err := linkSetMTU(link, types.HostInterfaceMTU); err != nil {
+		log.WithError(err).Errorf("Failed to set MTU %v for host interface", types.HostInterfaceMTU)
+		return err
+	}
+	log.Infof("Host interface MTU is set: %v", types.HostInterfaceMTU)
+
 	if err := linkSetUp(link); err != nil {
 		log.WithError(err).Error("Failed to set interface up")
 		return err

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -49,6 +49,7 @@ const (
 	HostInterfaceRefId          = "hostInterface"
 	DefaultRoute                = "169.254.1.1/32"
 	HostInterfaceAddr           = "200.1.1.2/32"
+	HostInterfaceMTU            = 1280
 	ArpProxyDefaultPort         = 0
 )
 


### PR DESCRIPTION
Set host TAP interface MTU to 1280.

Signed-off-by: Abdul Halim <abdul.halim@intel.com>