### PR TITLE
change host side PodCIDR route to GW address

### DIFF
--- a/pkg/netconf/ipvlan.go
+++ b/pkg/netconf/ipvlan.go
@@ -83,7 +83,11 @@ func setupRouting(ipList []netlink.Addr) error {
 		logger.WithError(err).Error("Cannot get Infra host interface")
 		return err
 	}
-	if err := setupHostRoute(ipList[0].IPNet, infraHostLink); err != nil {
+	gw, err := netlink.ParseAddr(types.DefaultRoute)
+	if err != nil {
+		return fmt.Errorf("Failed to pasre DefaultRoute GW addr %s: %w", types.DefaultRoute, err)
+	}
+	if err := setupHostRoute(ipList[0].IPNet, gw.IPNet, infraHostLink); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Change host route for PodCIDR to gateway address. Current change will set following host route entry:

```
169.254.1.1 dev P4TAP_0 scope link
192.168.0.0/24 via 169.254.1.1 dev P4TAP_0
192.168.0.0/16 via 169.254.1.1 dev P4TAP_0
```

Where:

- 169.254.1.1 is the gateway address in the pipeline. 
- 192.168.0.0/24 is Node PodCIDR block
- 192.168.0.0/16 is cluster PodCIDR block
- P4TAP_0 is the host interface connected to pipeline.
- 169.254.1.1 is expected to be configured on another interface from the pipeline.

The ServiceCIDR route entry from host side is removed.

Signed-off-by: Abdul Halim <abdul.halim@intel.com>