### PR TITLE
handle errors from health check watcher error channel

### DIFF
--- a/pkg/utils/grpc_watcher.go
+++ b/pkg/utils/grpc_watcher.go
@@ -60,9 +60,9 @@ func (gw *grpcWatcher) handleEvents() {
 			gw.errors <- fmt.Errorf("quit signal received")
 			return
 		default:
-			if isServing, err := gw.checkHealth(gw.target, gw.log, gw.dialFunc); isServing {
+			if isServing, _ := gw.checkHealth(gw.target, gw.log, gw.dialFunc); isServing {
 				gw.done <- true
-				gw.errors <- err
+				gw.errors <- nil
 				return
 			}
 			time.Sleep(gw.sleepDuration)
@@ -71,10 +71,7 @@ func (gw *grpcWatcher) handleEvents() {
 }
 
 func (gw *grpcWatcher) initialCheck() bool {
-	status, err := gw.checkHealth(gw.target, gw.log, gw.dialFunc)
-	if err != nil {
-		gw.log.Infof("checkHealth received error: %v", err)
-	}
+	status, _ := gw.checkHealth(gw.target, gw.log, gw.dialFunc)
 	return status
 }
 

--- a/pkg/utils/grpc_watcher.go
+++ b/pkg/utils/grpc_watcher.go
@@ -60,9 +60,9 @@ func (gw *grpcWatcher) handleEvents() {
 			gw.errors <- fmt.Errorf("quit signal received")
 			return
 		default:
-			if isServing, _ := gw.checkHealth(gw.target, gw.log, gw.dialFunc); isServing {
+			if isServing, err := gw.checkHealth(gw.target, gw.log, gw.dialFunc); isServing {
 				gw.done <- true
-				gw.errors <- nil
+				gw.errors <- err
 				return
 			}
 			time.Sleep(gw.sleepDuration)
@@ -71,7 +71,10 @@ func (gw *grpcWatcher) handleEvents() {
 }
 
 func (gw *grpcWatcher) initialCheck() bool {
-	status, _ := gw.checkHealth(gw.target, gw.log, gw.dialFunc)
+	status, err := gw.checkHealth(gw.target, gw.log, gw.dialFunc)
+	if err != nil {
+		gw.log.Infof("checkHealth received error: %v", err)
+	}
 	return status
 }
 

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1096,6 +1096,7 @@ type fakeWatcher struct {
 
 func (fs *fakeWatcher) handleEvents() {
 	<-fs.quit
+	fs.errors <- fmt.Errorf("quiting")
 }
 
 func (fs *fakeWatcher) initialCheck() bool {


### PR DESCRIPTION
This fixes the coverity scan issue on error checking on error channel from health check watcher.

Signed-off-by: Abdul Halim <abdul.halim@intel.com>