### PR TITLE
Fixed delete network bug.

### DIFF
--- a/pkg/inframanager/store/store_suite_test.go
+++ b/pkg/inframanager/store/store_suite_test.go
@@ -189,16 +189,6 @@ var _ = Describe("Storeendpoint", func() {
 				Expect(ret).To(Equal(false))
 			})
 
-			It("returns error when mac address is invalid", func() {
-				data_invalid3 := store.EndPoint{
-					PodIpAddress:  "10.10.10.1",
-					InterfaceID:   1,
-					PodMacAddress: "10.10.10.1",
-				}
-				ret := data_invalid3.DeleteFromStore()
-				Expect(ret).To(Equal(false))
-			})
-
 		})
 
 	})
@@ -229,16 +219,6 @@ var _ = Describe("Storeendpoint", func() {
 					PodMacAddress: "00:00:00:aa:aa:aa",
 				}
 				ret := data_invalid1.GetFromStore()
-				Expect(ret).Should(BeNil())
-			})
-
-			It("returns nil when mac address is invalid", func() {
-				data_invalid3 := store.EndPoint{
-					PodIpAddress:  "10.10.10.1",
-					InterfaceID:   1,
-					PodMacAddress: "10.10.10.1",
-				}
-				ret := data_invalid3.GetFromStore()
 				Expect(ret).Should(BeNil())
 			})
 

--- a/pkg/inframanager/store/storeendpoint.go
+++ b/pkg/inframanager/store/storeendpoint.go
@@ -102,12 +102,6 @@ func (ep EndPoint) DeleteFromStore() bool {
 		return false
 	}
 
-	_, err := net.ParseMAC(ep.PodMacAddress)
-	if err != nil {
-		log.Errorf("Invalid MAC Address %s", ep.PodMacAddress)
-		return false
-	}
-
 	//aquire lock before adding entry into the map
 	EndPointSet.EndPointLock.Lock()
 	//delete tmp entry from the map
@@ -120,12 +114,6 @@ func (ep EndPoint) DeleteFromStore() bool {
 func (ep EndPoint) GetFromStore() store {
 	if net.ParseIP(ep.PodIpAddress) == nil {
 		log.Errorf("Invalid IP Address %s", ep.PodIpAddress)
-		return nil
-	}
-
-	_, err := net.ParseMAC(ep.PodMacAddress)
-	if err != nil {
-		log.Errorf("Invalid MAC Address %s", ep.PodMacAddress)
 		return nil
 	}
 


### PR DESCRIPTION
There were unnecessary mac address sanity check done for getting and deleting entries from the endpoint store. As the key is only the IP address, we don't need to validate the macaddress in the request and moreover the caller functions might not have the mac information. So, deleting the mac address sanity checks. 
Signed-off-by: Venkatesh Petla <neelakanta.venkatesh.petla@intel.com>